### PR TITLE
feat: hoàn thiện demo quản lý đặt sân cầu lông (CRUD, trạng thái, thống kê, export/import)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ Ngày làm bài: 20/09/2025
 ## Mục tiêu
 - Thành thạo Git cơ bản và teamwork
 - Rèn kỹ năng commit, branch, push, rollback
+
+## Demo đồ án 2: Quản lý đặt sân cầu lông
+- Thư mục demo: `app/`
+- Mở nhanh: `app/index.html`
+- Mô tả chi tiết: `app/README.md`

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,28 @@
+# Ứng dụng quản lý đặt sân cầu lông (phiên bản hoàn thiện cho đồ án 2)
+
+## Tính năng đã hoàn thiện
+- Tạo / sửa / xóa lịch đặt sân.
+- Kiểm tra trùng lịch theo `sân + ngày + khung giờ`.
+- Quản lý trạng thái lịch: `Chờ xác nhận`, `Đã xác nhận`, `Hoàn tất`, `Đã hủy`.
+- Tính tổng tiền theo công thức:
+  - `Tổng tiền = (Số giờ thuê × Giá sân/giờ) + Phụ thu dịch vụ`.
+- Lọc dữ liệu theo từ khóa, trạng thái, ngày.
+- Thống kê nhanh: tổng lịch, lịch hôm nay, số lịch hoàn tất, doanh thu hoàn tất.
+- Xuất/nhập dữ liệu JSON để sao lưu hoặc chuyển máy.
+- Lưu dữ liệu cục bộ qua `localStorage`.
+
+## Cách chạy
+1. Mở trực tiếp `app/index.html` bằng trình duyệt.
+2. Hoặc chạy static server:
+
+```bash
+python3 -m http.server 4173
+```
+
+Truy cập: `http://localhost:4173/app/`
+
+## Gợi ý nâng cấp backend (nếu cần nộp full-stack)
+- Tách API riêng (Node.js/Express hoặc ASP.NET Web API).
+- Lưu lịch vào MySQL/PostgreSQL thay cho `localStorage`.
+- Thêm phân quyền người dùng (Admin/Nhân viên).
+- Bổ sung module hóa đơn PDF + thống kê theo khoảng thời gian.

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<html lang="vi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quản lý đặt sân cầu lông</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="container page-header">
+      <div>
+        <h1>🏸 Quản lý đặt sân cầu lông</h1>
+        <p>Phiên bản hoàn thiện cho đồ án 2: quản lý lịch, trạng thái, doanh thu và dữ liệu.</p>
+      </div>
+      <div class="actions">
+        <button id="export-btn" type="button" class="outline">Xuất JSON</button>
+        <label class="import-label" for="import-file">Nhập JSON</label>
+        <input id="import-file" type="file" accept="application/json" hidden />
+      </div>
+    </header>
+
+    <main class="container layout">
+      <section class="card stats" aria-label="Tổng quan">
+        <article>
+          <p>Tổng lịch đặt</p>
+          <h3 id="stat-total">0</h3>
+        </article>
+        <article>
+          <p>Lịch hôm nay</p>
+          <h3 id="stat-today">0</h3>
+        </article>
+        <article>
+          <p>Đã hoàn tất</p>
+          <h3 id="stat-completed">0</h3>
+        </article>
+        <article>
+          <p>Doanh thu (hoàn tất)</p>
+          <h3 id="stat-revenue">0 đ</h3>
+        </article>
+      </section>
+
+      <section class="card">
+        <h2 id="form-title">Tạo lịch đặt mới</h2>
+        <form id="booking-form">
+          <input id="editingId" type="hidden" />
+
+          <div class="row two-cols">
+            <label>
+              Tên người đặt
+              <input id="customerName" type="text" required placeholder="Ví dụ: Nguyễn Văn A" />
+            </label>
+
+            <label>
+              Số điện thoại
+              <input id="phone" type="tel" required pattern="[0-9]{9,11}" placeholder="Ví dụ: 0901234567" />
+            </label>
+          </div>
+
+          <div class="row four-cols">
+            <label>
+              Sân
+              <select id="court" required>
+                <option value="">-- Chọn sân --</option>
+                <option>Sân 1</option>
+                <option>Sân 2</option>
+                <option>Sân 3</option>
+                <option>Sân 4</option>
+              </select>
+            </label>
+
+            <label>
+              Ngày
+              <input id="date" type="date" required />
+            </label>
+
+            <label>
+              Giờ bắt đầu
+              <input id="startTime" type="time" required />
+            </label>
+
+            <label>
+              Giờ kết thúc
+              <input id="endTime" type="time" required />
+            </label>
+          </div>
+
+          <div class="row three-cols">
+            <label>
+              Trạng thái
+              <select id="status" required>
+                <option value="pending">Chờ xác nhận</option>
+                <option value="confirmed">Đã xác nhận</option>
+                <option value="completed">Hoàn tất</option>
+                <option value="cancelled">Đã hủy</option>
+              </select>
+            </label>
+
+            <label>
+              Giá sân / giờ (VND)
+              <input id="hourlyRate" type="number" min="0" step="10000" value="120000" required />
+            </label>
+
+            <label>
+              Phụ thu dịch vụ (VND)
+              <input id="serviceFee" type="number" min="0" step="10000" value="0" required />
+            </label>
+          </div>
+
+          <label>
+            Ghi chú
+            <textarea id="note" rows="2" placeholder="Ví dụ: đặt thêm vợt và 2 ống cầu"></textarea>
+          </label>
+
+          <div class="actions">
+            <button type="submit" id="save-btn">Thêm lịch đặt</button>
+            <button type="button" id="reset-btn" class="outline">Làm mới form</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="card">
+        <div class="table-header">
+          <h2>Danh sách lịch đặt</h2>
+          <div class="filters">
+            <input id="search" type="search" placeholder="Tìm tên, SĐT hoặc sân" />
+            <select id="filterStatus">
+              <option value="">Tất cả trạng thái</option>
+              <option value="pending">Chờ xác nhận</option>
+              <option value="confirmed">Đã xác nhận</option>
+              <option value="completed">Hoàn tất</option>
+              <option value="cancelled">Đã hủy</option>
+            </select>
+            <input id="filterDate" type="date" />
+          </div>
+        </div>
+
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Khách</th>
+                <th>Sân</th>
+                <th>Thời gian</th>
+                <th>Trạng thái</th>
+                <th>Tổng tiền</th>
+                <th>Liên hệ</th>
+                <th>Ghi chú</th>
+                <th>Hành động</th>
+              </tr>
+            </thead>
+            <tbody id="booking-body"></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <template id="row-template">
+      <tr>
+        <td data-field="customer"></td>
+        <td data-field="court"></td>
+        <td data-field="time"></td>
+        <td data-field="status"></td>
+        <td data-field="total"></td>
+        <td data-field="phone"></td>
+        <td data-field="note"></td>
+        <td>
+          <div class="row-actions">
+            <button type="button" data-action="edit" class="small">Sửa</button>
+            <button type="button" data-action="delete" class="small danger">Xóa</button>
+          </div>
+        </td>
+      </tr>
+    </template>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/app/script.js
+++ b/app/script.js
@@ -1,0 +1,327 @@
+const STORAGE_KEY = "badmintonBookingsV2";
+
+const form = document.getElementById("booking-form");
+const tbody = document.getElementById("booking-body");
+const rowTemplate = document.getElementById("row-template");
+
+const searchInput = document.getElementById("search");
+const filterStatus = document.getElementById("filterStatus");
+const filterDate = document.getElementById("filterDate");
+
+const exportBtn = document.getElementById("export-btn");
+const importFile = document.getElementById("import-file");
+const resetBtn = document.getElementById("reset-btn");
+const formTitle = document.getElementById("form-title");
+const saveBtn = document.getElementById("save-btn");
+
+const stats = {
+  total: document.getElementById("stat-total"),
+  today: document.getElementById("stat-today"),
+  completed: document.getElementById("stat-completed"),
+  revenue: document.getElementById("stat-revenue"),
+};
+
+const fields = {
+  editingId: document.getElementById("editingId"),
+  customerName: document.getElementById("customerName"),
+  phone: document.getElementById("phone"),
+  court: document.getElementById("court"),
+  date: document.getElementById("date"),
+  startTime: document.getElementById("startTime"),
+  endTime: document.getElementById("endTime"),
+  status: document.getElementById("status"),
+  hourlyRate: document.getElementById("hourlyRate"),
+  serviceFee: document.getElementById("serviceFee"),
+  note: document.getElementById("note"),
+};
+
+const STATUS_LABEL = {
+  pending: "Chờ xác nhận",
+  confirmed: "Đã xác nhận",
+  completed: "Hoàn tất",
+  cancelled: "Đã hủy",
+};
+
+function formatCurrency(value) {
+  return new Intl.NumberFormat("vi-VN", { style: "currency", currency: "VND" }).format(value);
+}
+
+function toMinutes(time) {
+  const [hour, minute] = time.split(":").map(Number);
+  return hour * 60 + minute;
+}
+
+function calcDurationHours(startTime, endTime) {
+  return Math.max(0, (toMinutes(endTime) - toMinutes(startTime)) / 60);
+}
+
+function calcTotal(booking) {
+  const duration = calcDurationHours(booking.startTime, booking.endTime);
+  return Math.round(duration * booking.hourlyRate + booking.serviceFee);
+}
+
+function normalizeBooking(raw) {
+  return {
+    ...raw,
+    hourlyRate: Number(raw.hourlyRate) || 0,
+    serviceFee: Number(raw.serviceFee) || 0,
+    status: raw.status || "pending",
+    note: raw.note || "",
+  };
+}
+
+function loadBookings() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.map(normalizeBooking) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveBookings(items) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+}
+
+function overlaps(a, b) {
+  return a.startTime < b.endTime && b.startTime < a.endTime;
+}
+
+function validateBooking(booking, existingBookings) {
+  if (booking.startTime >= booking.endTime) {
+    return "Giờ kết thúc phải lớn hơn giờ bắt đầu.";
+  }
+
+  if (!booking.customerName || !booking.phone || !booking.court || !booking.date) {
+    return "Vui lòng nhập đầy đủ thông tin bắt buộc.";
+  }
+
+  if (!/^\d{9,11}$/.test(booking.phone)) {
+    return "Số điện thoại phải gồm 9-11 chữ số.";
+  }
+
+  const conflict = existingBookings.find((item) => {
+    if (item.id === booking.id) return false;
+    return item.court === booking.court && item.date === booking.date && overlaps(item, booking);
+  });
+
+  if (conflict) {
+    return `Sân ${booking.court} đã có lịch trong khung giờ này.`;
+  }
+
+  return "";
+}
+
+function formatTimeRange(booking) {
+  return `${booking.date} | ${booking.startTime} - ${booking.endTime}`;
+}
+
+function getBookingFromForm() {
+  const editingId = fields.editingId.value;
+
+  return {
+    id: editingId || crypto.randomUUID(),
+    customerName: fields.customerName.value.trim(),
+    phone: fields.phone.value.trim(),
+    court: fields.court.value,
+    date: fields.date.value,
+    startTime: fields.startTime.value,
+    endTime: fields.endTime.value,
+    status: fields.status.value,
+    hourlyRate: Number(fields.hourlyRate.value) || 0,
+    serviceFee: Number(fields.serviceFee.value) || 0,
+    note: fields.note.value.trim(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function getFilterState() {
+  return {
+    keyword: searchInput.value.trim().toLowerCase(),
+    status: filterStatus.value,
+    date: filterDate.value,
+  };
+}
+
+function getVisibleBookings(items) {
+  const filter = getFilterState();
+  return items.filter((item) => {
+    const content = `${item.customerName} ${item.phone} ${item.court}`.toLowerCase();
+    const matchKeyword = !filter.keyword || content.includes(filter.keyword);
+    const matchStatus = !filter.status || item.status === filter.status;
+    const matchDate = !filter.date || item.date === filter.date;
+    return matchKeyword && matchStatus && matchDate;
+  });
+}
+
+function renderStats(items) {
+  const today = new Date().toISOString().slice(0, 10);
+  const completed = items.filter((item) => item.status === "completed");
+  const revenue = completed.reduce((sum, item) => sum + calcTotal(item), 0);
+
+  stats.total.textContent = String(items.length);
+  stats.today.textContent = String(items.filter((item) => item.date === today).length);
+  stats.completed.textContent = String(completed.length);
+  stats.revenue.textContent = formatCurrency(revenue);
+}
+
+function render(items) {
+  tbody.innerHTML = "";
+  const visible = getVisibleBookings(items);
+
+  visible
+    .slice()
+    .sort((a, b) => `${a.date}${a.startTime}`.localeCompare(`${b.date}${b.startTime}`))
+    .forEach((item) => {
+      const fragment = rowTemplate.content.cloneNode(true);
+      const row = fragment.querySelector("tr");
+
+      fragment.querySelector('[data-field="customer"]').textContent = item.customerName;
+      fragment.querySelector('[data-field="court"]').textContent = item.court;
+      fragment.querySelector('[data-field="time"]').textContent = formatTimeRange(item);
+      fragment.querySelector('[data-field="status"]').innerHTML = `<span class="badge ${item.status}">${
+        STATUS_LABEL[item.status]
+      }</span>`;
+      fragment.querySelector('[data-field="total"]').textContent = formatCurrency(calcTotal(item));
+      fragment.querySelector('[data-field="phone"]').textContent = item.phone;
+      fragment.querySelector('[data-field="note"]').textContent = item.note || "-";
+
+      row.dataset.id = item.id;
+      tbody.appendChild(fragment);
+    });
+
+  if (!visible.length) {
+    const empty = document.createElement("tr");
+    empty.innerHTML = '<td colspan="8" class="empty">Không có lịch đặt phù hợp bộ lọc.</td>';
+    tbody.appendChild(empty);
+  }
+
+  renderStats(items);
+}
+
+function resetForm() {
+  form.reset();
+  fields.editingId.value = "";
+  fields.hourlyRate.value = "120000";
+  fields.serviceFee.value = "0";
+  fields.status.value = "pending";
+  formTitle.textContent = "Tạo lịch đặt mới";
+  saveBtn.textContent = "Thêm lịch đặt";
+}
+
+function fillFormForEdit(booking) {
+  fields.editingId.value = booking.id;
+  fields.customerName.value = booking.customerName;
+  fields.phone.value = booking.phone;
+  fields.court.value = booking.court;
+  fields.date.value = booking.date;
+  fields.startTime.value = booking.startTime;
+  fields.endTime.value = booking.endTime;
+  fields.status.value = booking.status;
+  fields.hourlyRate.value = String(booking.hourlyRate);
+  fields.serviceFee.value = String(booking.serviceFee);
+  fields.note.value = booking.note || "";
+
+  formTitle.textContent = "Chỉnh sửa lịch đặt";
+  saveBtn.textContent = "Cập nhật lịch";
+}
+
+function exportBookings(items) {
+  const blob = new Blob([JSON.stringify(items, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `badminton-bookings-${new Date().toISOString().slice(0, 10)}.json`;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+function importBookingsFromFile(file) {
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const parsed = JSON.parse(String(reader.result || "[]"));
+      if (!Array.isArray(parsed)) throw new Error("invalid");
+      bookings = parsed.map(normalizeBooking);
+      saveBookings(bookings);
+      render(bookings);
+      resetForm();
+      alert("Nhập dữ liệu thành công.");
+    } catch {
+      alert("File JSON không hợp lệ.");
+    }
+  };
+  reader.readAsText(file);
+}
+
+let bookings = loadBookings();
+render(bookings);
+resetForm();
+
+form.addEventListener("submit", (event) => {
+  event.preventDefault();
+
+  const booking = getBookingFromForm();
+  const message = validateBooking(booking, bookings);
+
+  if (message) {
+    alert(message);
+    return;
+  }
+
+  const index = bookings.findIndex((item) => item.id === booking.id);
+  if (index === -1) {
+    bookings.push(booking);
+  } else {
+    bookings[index] = booking;
+  }
+
+  saveBookings(bookings);
+  render(bookings);
+  resetForm();
+});
+
+tbody.addEventListener("click", (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLButtonElement)) return;
+
+  const row = target.closest("tr");
+  if (!row?.dataset.id) return;
+
+  const booking = bookings.find((item) => item.id === row.dataset.id);
+  if (!booking) return;
+
+  if (target.dataset.action === "edit") {
+    fillFormForEdit(booking);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+    return;
+  }
+
+  if (target.dataset.action === "delete") {
+    const accepted = confirm(`Xóa lịch của ${booking.customerName} (${booking.court})?`);
+    if (!accepted) return;
+    bookings = bookings.filter((item) => item.id !== booking.id);
+    saveBookings(bookings);
+    render(bookings);
+    resetForm();
+  }
+});
+
+[searchInput, filterStatus, filterDate].forEach((element) => {
+  element.addEventListener("input", () => render(bookings));
+});
+
+resetBtn.addEventListener("click", resetForm);
+
+exportBtn.addEventListener("click", () => exportBookings(bookings));
+
+importFile.addEventListener("change", () => {
+  const file = importFile.files?.[0];
+  if (file) {
+    importBookingsFromFile(file);
+  }
+  importFile.value = "";
+});

--- a/app/styles.css
+++ b/app/styles.css
@@ -1,0 +1,244 @@
+:root {
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  color: #0f172a;
+  background: #eef2ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.container {
+  width: min(1200px, 92%);
+  margin: 0 auto;
+}
+
+.page-header {
+  padding: 2rem 0 1rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: start;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+.page-header p {
+  margin-top: 0.4rem;
+  color: #475569;
+}
+
+.layout {
+  display: grid;
+  gap: 1rem;
+  padding-bottom: 2rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 14px;
+  padding: 1rem;
+  box-shadow: 0 10px 30px rgba(30, 41, 59, 0.08);
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(160px, 1fr));
+  gap: 0.8rem;
+}
+
+.stats article {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 0.8rem;
+}
+
+.stats p {
+  color: #475569;
+  margin-bottom: 0.25rem;
+}
+
+form {
+  display: grid;
+  gap: 0.8rem;
+}
+
+label {
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.92rem;
+  color: #334155;
+}
+
+input,
+select,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+select,
+textarea {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 0.6rem 0.7rem;
+}
+
+button,
+.import-label {
+  border: none;
+  border-radius: 8px;
+  background: #2563eb;
+  color: #fff;
+  padding: 0.65rem 0.9rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+}
+
+button:hover,
+.import-label:hover {
+  opacity: 0.95;
+}
+
+button.outline {
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  color: #0f172a;
+}
+
+button.danger {
+  background: #ef4444;
+}
+
+.actions {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.row {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.two-cols {
+  grid-template-columns: repeat(2, minmax(220px, 1fr));
+}
+
+.three-cols {
+  grid-template-columns: repeat(3, minmax(200px, 1fr));
+}
+
+.four-cols {
+  grid-template-columns: repeat(4, minmax(160px, 1fr));
+}
+
+.table-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.filters {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+  padding: 0.55rem 0.35rem;
+  vertical-align: top;
+}
+
+thead {
+  background: #f8fafc;
+}
+
+.badge {
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.badge.pending {
+  color: #92400e;
+  background: #fef3c7;
+}
+
+.badge.confirmed {
+  color: #1d4ed8;
+  background: #dbeafe;
+}
+
+.badge.completed {
+  color: #166534;
+  background: #dcfce7;
+}
+
+.badge.cancelled {
+  color: #991b1b;
+  background: #fee2e2;
+}
+
+.row-actions {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.small {
+  padding: 0.35rem 0.5rem;
+  font-size: 0.82rem;
+}
+
+.empty {
+  text-align: center;
+  color: #64748b;
+  padding: 1rem;
+}
+
+@media (max-width: 960px) {
+  .stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .page-header,
+  .table-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .two-cols,
+  .three-cols,
+  .four-cols {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Motivation
- Nâng cấp demo frontend trong `app/` để có thể dùng ngay cho đồ án 2 với luồng quản lý lịch đầy đủ hơn (CRUD, trạng thái, tính tiền, lọc, xuất/nhập dữ liệu, thống kê).  
- Mục tiêu là cung cấp bản demo tĩnh dễ chạy, có giao diện responsive và logic xử lý đủ cho phần trình bày/democase mà không cần backend.  
- Skills: không sử dụng skill bổ sung từ `AGENTS.md` trong bước này (chỉ cập nhật mã nguồn trực tiếp).  

### Description
- Thêm/hoàn thiện giao diện và logic trong thư mục `app/` bao gồm `index.html`, `script.js`, `styles.css` và tài liệu `app/README.md`.  
- Form nâng cấp: hỗ trợ tạo và chỉnh sửa lịch, trường trạng thái (`pending|confirmed|completed|cancelled`), `hourlyRate` và `serviceFee`.  
- Business logic: kiểm tra trùng lịch theo `court + date + time range`, tính tổng tiền theo giờ + phụ thu, validate đầu vào (SĐT, thời gian), chế độ edit, reset form.  
- Giao diện dữ liệu: bảng hiện trạng với badge trạng thái, hiển thị tổng tiền từng lịch, bộ lọc (từ khóa / trạng thái / ngày), dashboard thống kê (tổng lịch, lịch hôm nay, số hoàn tất, doanh thu từ lịch hoàn tất).  
- Backup/restore: nút xuất JSON và nhập JSON để sao lưu/phục hồi dữ liệu vào `localStorage`.

### Testing
- `node --check app/script.js` được chạy và thành công.  
- Mở static server `python3 -m http.server 4173` và kiểm tra giao diện bằng kịch bản Playwright (tự động điền form, lưu một lịch, áp filter và chụp screenshot); kịch bản đã chạy và sinh screenshot thành công.  
- Kiểm tra manual cơ bản qua trình duyệt (thêm/sửa/xóa lịch, lọc, xuất/nhập JSON, thống kê) được thực hiện và hoạt động như mong đợi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb332b4d48328b0989d5627eb3b25)